### PR TITLE
Back to basics

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,5 @@
 # global/supervisord config
 
-supervisor_deb_file_location: "/tmp/{{ supervisor_deb_file }}"
-
 supervisor_config_dir: "/etc/supervisor/conf.d/"
 supervisorctl_command: "supervisorctl"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,0 @@
----
-- name: update supervisord
-  command: "{{ supervisorctl_command }} update {{ name }}"
-  sudo: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,4 +18,3 @@ galaxy_info:
   - system
   - web
 dependencies: []
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,44 +6,7 @@
     cache_valid_time=3600
   with_items:
     - python-meld3
-  sudo: yes
-
-- name: Check supervisor package installed (if any)
-  shell: "dpkg-query --showformat='${Version}' --show supervisor"
-  register: supervisor_package_installed
-  failed_when: no  # so that we don't fail/stop here when supervisor is not installed
-
-- include_vars: "{{ ansible_distribution_version }}.yml"
-
-- set_fact:
-    install_supervisor={{ supervisor_version not in supervisor_package_installed.stdout }}
-
-- name: Download supervisor package
-  raw: wget https://launchpad.net/ubuntu/+archive/primary/+files/{{ supervisor_deb_file }} -O {{ supervisor_deb_file_location }}
-  sudo: yes
-  when: install_supervisor
-
-- name: Install supervisor package
-  apt: deb={{ supervisor_deb_file_location }} state=present
-  sudo: yes
-  when: install_supervisor
-
-# Sometimes the service refuses to run on its own after installing the package
-- name: Make sure supervisor is running
-  service: name=supervisor state=started
-  sudo: yes
-
-- name: Delete supervisor .deb file
-  file:
-    path={{ supervisor_deb_file_location }}
-    state=absent
-  sudo: yes
-
-- name: Ensure backwards compatibility for config location
-  file:
-    src=/etc/supervisor/supervisord.conf
-    dest=/etc/supervisord.conf
-    state=link
+    - supervisor
   sudo: yes
 
 - name: Installing task {{ name }}
@@ -56,10 +19,5 @@
 
 - name: Restart task {{ name }}
   command: "{{ supervisorctl_command }} restart {{ name }}:*"
-  when: ansible_distribution_version == "12.04" or restart_task
-  sudo: yes
-
-- name: Send {{ signal_task }} signal to task {{ name }}
-  command: "{{ supervisorctl_command }} signal {{ signal_task }} {{ name }}:*"
-  when: ansible_distribution_version != "12.04" and signal_task is defined
+  when: restart_task
   sudo: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,6 @@
     update_cache=yes
     cache_valid_time=3600
   with_items:
-    - python-meld3
     - supervisor
   sudo: yes
 

--- a/vars/12.04.yml
+++ b/vars/12.04.yml
@@ -1,2 +1,0 @@
-supervisor_deb_file: "supervisor_3.0a8-1.1_all.deb"
-supervisor_version: "3.0a8-1.1"

--- a/vars/14.04.yml
+++ b/vars/14.04.yml
@@ -1,2 +1,0 @@
-supervisor_deb_file: "supervisor_3.2.0-2_all.deb"
-supervisor_version: "3.2.0"


### PR DESCRIPTION
@EDITD/hackers This simplifies the role a lot, by removing the idea of installing a custom supervisor `.deb`.

It's proven to be a very unclean solution for us, and the benefit of getting to use supervisor 3.2 (the original intention of these changes) was overshadowed by the issues it came with. We needed 3.2 to support signaling, but we can do outside the scope of supervisor in the first place (i.e. through an ansible task).