### PR TITLE
Home var

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A role for creating supervisor tasks.
 
-**NOTE**: This role depends on facts being gathered and will fail when `gather_facts` is set to false/no.
-
 
 ## Actions
 
@@ -36,27 +34,6 @@ By default, the role will restart the task on each run, which you could skip lik
       user: ubuntu
       restart_task: no
 ```
-
-### Signaling tasks:
-
-Starting with supervisor 3.2.0, there is also the ability to send signals to tasks.
-A good example where this might come in handy is signaling web servers, e.g. uwsgi,
-to gracefully restart their workers. An example of how to do that would be:
-
-```
-  roles:
-    - role: EDITD.supervisor_task
-      name: webserver
-      command: uwsgi
-      directory: /opt/web
-      user: ubuntu
-      restart_task: no
-      signal_task: HUP
-```
-
-Unfortunately versions 3.2.0+ of supervisor are not compatible with Ubuntu 12.04,
-in which case an older supervisor version is installed instead, without signaling support.
-In these systems tasks will always be restarted, even when `restart: no` is passed to the role.
 
 ## License
 

--- a/templates/task.conf.j2
+++ b/templates/task.conf.j2
@@ -7,9 +7,7 @@ autostart={{ autostart }}
 autorestart={{ autorestart }}
 user={{ user }}
 numprocs={{ numprocs }}
+environment={% if 'USER' not in env_vars %}USER="{{ user }}",{% endif %}{% if 'HOME' not in env_vars %}HOME="/home/{{ user }}",{% endif %}{% for name, value in env_vars.iteritems() %}{{ name }}="{{ value }}",{% endfor %}
 {% if stopsignal is defined %}
 stopsignal={{ stopsignal }}
-{% endif %}
-{% if env_vars|length > 0 %}
-environment={% if 'USER' not in env_vars %}USER={{ user }},{% endif %}{% if 'HOME' not in env_vars %}HOME=/home/{{ user }},{% endif %}{% for name, value in env_vars.iteritems() %}{{ name }}="{{ value }}"{% if not loop.last %},{% endif %}{% endfor %}
 {% endif %}

--- a/templates/task.conf.j2
+++ b/templates/task.conf.j2
@@ -11,5 +11,5 @@ numprocs={{ numprocs }}
 stopsignal={{ stopsignal }}
 {% endif %}
 {% if env_vars|length > 0 %}
-environment={% if 'HOME' not in env_vars %}HOME=/home/{{ user }},{% endif %}{% for name, value in env_vars.iteritems() %}{{ name }}="{{ value }}"{% if not loop.last %},{% endif %}{% endfor %}
+environment={% if 'USER' not in env_vars %}USER={{ user }},{% endif %}{% if 'HOME' not in env_vars %}HOME=/home/{{ user }},{% endif %}{% for name, value in env_vars.iteritems() %}{{ name }}="{{ value }}"{% if not loop.last %},{% endif %}{% endfor %}
 {% endif %}

--- a/templates/task.conf.j2
+++ b/templates/task.conf.j2
@@ -11,5 +11,5 @@ numprocs={{ numprocs }}
 stopsignal={{ stopsignal }}
 {% endif %}
 {% if env_vars|length > 0 %}
-environment={% for name, value in env_vars.iteritems() %}{{ name }}="{{ value }}"{% if not loop.last %},{% endif %}{% endfor %}
+environment={% if 'HOME' not in env_vars %}HOME=/home/{{ user }},{% endif %}{% for name, value in env_vars.iteritems() %}{{ name }}="{{ value }}"{% if not loop.last %},{% endif %}{% endfor %}
 {% endif %}


### PR DESCRIPTION
@EDITD/hackers This introduces the `HOME` env var we need to help python scripts that run through supervisor get to the correct home location (for example when using `os.path.expanduser()`.