### PR TITLE
Enable supervisor on system start by default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   when: '{{ state == "absent" }}'
 
 - name: Ensure supervisord is started
-  service: name=supervisor state=started
+  service: name=supervisor state=started enabled=yes
   sudo: yes
 
 - name: Update supervisor


### PR DESCRIPTION
@EDITD/hackers This makes sure the supervisor service runs on system start. We noticed that on Ubuntu 16.04 this is no longer the default (cause systemd).